### PR TITLE
refine drag-n-drop logic

### DIFF
--- a/src/frontend/components/Breadcrumbs.tsx
+++ b/src/frontend/components/Breadcrumbs.tsx
@@ -50,8 +50,10 @@ export interface CrumbItemProps {
 
 export function CrumbItem({ part, path, onClick, onFileDrop }: CrumbItemProps) {
   const { isOver, canDrop, drop } = useFileDrop({
-    nodePath: path,
-    isDirectory: true,
+    targetNode: {
+      path,
+      type: "directory",
+    },
     onFileDrop: (droppedPaths, targetPath) => {
       onFileDrop(droppedPaths, targetPath);
     },

--- a/src/frontend/components/FileItem.tsx
+++ b/src/frontend/components/FileItem.tsx
@@ -57,62 +57,59 @@ export function FileItem({
   );
 
   const { isOver, canDrop, drop } = useFileDrop({
-    nodePath: node.path,
-    isDirectory,
+    targetNode: node,
     onFileDrop,
   });
 
   const expandIcon = isDirectory ? (expanded ? "▼" : "▶") : null;
 
   return (
-    <div ref={drop}>
-      <div
-        ref={dragRef}
-        style={(() => {
-          const backgroundColor =
-            isOver && canDrop ? "#e3f2fd" : selected ? "#ddd" : "transparent";
-          return {
-            opacity,
-            backgroundColor,
-            border: isOver && canDrop ? "2px dashed #2196f3" : "none",
-            padding: isOver && canDrop ? "2px" : "4px",
-          };
-        })()}
-        role="listitem"
-        aria-label={node.name}
-        className={`file-item ${selected ? "selected" : ""}`}
-        data-level={level}
-        data-type={node.type}
-        data-name={node.name}
-        data-selected={selected}
-        data-expanded={expanded}
-        aria-expanded={expanded}
-        onClick={(e: React.MouseEvent) => {
-          e.stopPropagation();
-          if (onNameClick) {
-            onNameClick(e, node);
-          }
-        }}
-      >
-        {icon}
-        <span title={node.path} style={{ marginLeft: 5, marginRight: 5 }}>
-          {node.name}
+    <div
+      ref={(i) => dragRef(drop(i))}
+      style={{
+        paddingLeft: isOver && canDrop ? level * 20 - 4 : level * 20,
+        border: isOver && canDrop ? "2px dashed #2196f3" : "none",
+        padding: isOver && canDrop ? "2px" : "4px",
+        height: 29,
+        backgroundColor:
+          isOver && canDrop ? "#e3f2fd" : selected ? "#ddd" : "transparent",
+        opacity,
+        width: "100%",
+      }}
+      role="listitem"
+      aria-label={node.name}
+      className={`file-item ${selected ? "selected" : ""}`}
+      data-level={level}
+      data-type={node.type}
+      data-name={node.name}
+      data-selected={selected}
+      data-expanded={expanded}
+      aria-expanded={expanded}
+      onClick={(e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (onNameClick) {
+          onNameClick(e, node);
+        }
+      }}
+    >
+      {icon}
+      <span title={node.path} style={{ marginLeft: 5, marginRight: 5 }}>
+        {node.name}
+      </span>
+      {expandIcon && (
+        <span
+          aria-label={"Expand/Collapse " + node.name}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (onExpandToggle) onExpandToggle(node);
+          }}
+          role="button"
+          tabIndex={0}
+          className="expand-icon"
+        >
+          {expandIcon}
         </span>
-        {expandIcon && (
-          <span
-            aria-label={"Expand/Collapse " + node.name}
-            onClick={(e) => {
-              e.stopPropagation();
-              if (onExpandToggle) onExpandToggle(node);
-            }}
-            role="button"
-            tabIndex={0}
-            className="expand-icon"
-          >
-            {expandIcon}
-          </span>
-        )}
-      </div>
+      )}
     </div>
   );
 }

--- a/src/frontend/components/FileTree.tsx
+++ b/src/frontend/components/FileTree.tsx
@@ -79,29 +79,28 @@ export function FileTree({
     >
       <VirtualizedList listItemHeight={21}>
         {flattenedItems.map(({ node, level }) => (
-          <div key={node.path} style={{ paddingLeft: level * 20 }}>
-            <FileItem
-              selectedFilePaths={selectedFilePaths}
-              level={level}
-              onNameClick={(event: React.MouseEvent, node: FileNode) => {
-                switch (event.detail) {
-                  case 2:
-                    if (node.type === "directory" && onDrillDown) {
-                      onDrillDown(node);
-                    }
-                    break;
-                  default:
-                    handleItemSelect(event, node, sortingFunc);
-                    break;
-                }
-              }}
-              onExpandToggle={handleExpandleToggle}
-              onFileDrop={onFileDrop}
-              node={node}
-              selected={selectedFilePaths.has(node.path)}
-              expanded={expandedDirs.has(node.path)}
-            />
-          </div>
+          <FileItem
+            key={node.path}
+            selectedFilePaths={selectedFilePaths}
+            level={level}
+            onNameClick={(event: React.MouseEvent, node: FileNode) => {
+              switch (event.detail) {
+                case 2:
+                  if (node.type === "directory" && onDrillDown) {
+                    onDrillDown(node);
+                  }
+                  break;
+                default:
+                  handleItemSelect(event, node, sortingFunc);
+                  break;
+              }
+            }}
+            onExpandToggle={handleExpandleToggle}
+            onFileDrop={onFileDrop}
+            node={node}
+            selected={selectedFilePaths.has(node.path)}
+            expanded={expandedDirs.has(node.path)}
+          />
         ))}
       </VirtualizedList>
     </div>

--- a/src/frontend/components/VirtualizedList.tsx
+++ b/src/frontend/components/VirtualizedList.tsx
@@ -118,6 +118,11 @@ export function VirtualizedList({
               top: 0,
               left: 0,
               right: 0,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "flex-start",
+              // prevent wrapping which can cause height issues
+              whiteSpace: "nowrap",
             }}
           >
             {visibleChildren}

--- a/src/hooks/useFileDrop.ts
+++ b/src/hooks/useFileDrop.ts
@@ -1,33 +1,60 @@
 import { useDrop } from "react-dnd";
 
 interface UseFileDropParams {
-  nodePath: string;
-  isDirectory: boolean;
+  targetNode: {
+    path: string;
+    type: "file" | "directory";
+  };
   onFileDrop: (droppedPaths: string[], targetPath: string) => void;
 }
 
-export function useFileDrop({
-  nodePath,
-  isDirectory,
-  onFileDrop,
-}: UseFileDropParams) {
+export function useFileDrop({ targetNode, onFileDrop }: UseFileDropParams) {
   const [{ isOver, canDrop }, drop] = useDrop(
     () => ({
       accept: "file-system-node",
       drop: (item: string[]) => {
-        // Only allow dropping on directories
-        if (isDirectory && onFileDrop) {
-          onFileDrop(item, nodePath);
+        const targetIsDir = targetNode.type === "directory";
+        const targetNodePath = targetNode.path;
+        // If dropping onto a file, drop into that file's parent directory
+        if (!targetIsDir && onFileDrop) {
+          onFileDrop(
+            item,
+            targetNodePath.substring(0, targetNodePath.lastIndexOf("/")) || "/"
+          );
+          // If dropping onto a directory, drop into that directory
+        } else if (targetIsDir && onFileDrop) {
+          onFileDrop(item, targetNodePath);
         }
       },
-      canDrop: () => isDirectory, // Only directories can accept drops
+      canDrop: (item) => {
+        const targetNodepath = targetNode.path;
+        // If no items or no handler, cannot drop
+        if (!item.length || !onFileDrop) return false;
+        // Prevent dropping a single item into the directory its already in
+        if (item.length === 1) {
+          const parentPath = getParentPath(item[0]);
+          if (targetNode.type === "directory") {
+            if (parentPath === targetNodepath) return false;
+          } else if (parentPath === getParentPath(targetNodepath)) {
+            return false;
+          }
+        }
+        return true;
+      },
       collect: (monitor) => ({
         isOver: monitor.isOver(),
         canDrop: monitor.canDrop(),
       }),
     }),
-    [nodePath, isDirectory, onFileDrop]
+    [targetNode, onFileDrop]
   );
 
   return { isOver, canDrop, drop };
+}
+
+function getParentPath(path: string): string {
+  if (path === "/") return "/";
+  const parts = path.split("/").filter((p) => p.length > 0);
+  if (parts.length <= 1) return "/";
+  return "/" + parts.slice(0, parts.length - 1).join("/");
 }


### PR DESCRIPTION
Refine conditions of when an item can / cannot be dropped onto another. Dropping onto a non-directory item should put moved items into parent of target item.